### PR TITLE
Correction for Max Volumetric Speed calculation formula

### DIFF
--- a/Orca Slicer Assistant.html
+++ b/Orca Slicer Assistant.html
@@ -179,7 +179,7 @@
       var maxSpeedStart = parseFloat(document.getElementById("maxSpeedStart").value);
       var maxSpeedHeight = parseFloat(document.getElementById("maxSpeedHeight").value);
       var maxSpeedStep = parseFloat(document.getElementById("maxSpeedStep").value);
-      var result = maxSpeedStart + (maxSpeedHeight - maxSpeedHeight * maxSpeedStep);
+      var result = maxSpeedStart + (maxSpeedHeight * maxSpeedStep);
 
       document.getElementById("maxSpeedResult").textContent = "Result: " + result.toFixed(2);
       updateHistory("max-speed-history", result.toFixed(2));


### PR DESCRIPTION
The current formula only works if the value of "MaxSpeedStep" is 0.5. The modification involves replacing the line:

"var result = maxSpeedStart + (maxSpeedHeight - maxSpeedHeight * maxSpeedStep);"

with:

"var result = maxSpeedStart + (maxSpeedHeight * maxSpeedStep);"