### PR TITLE
tweak css so the number fields will be centered

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
             font-weight: 500;
         }
         input, select {
-            width: 100%;
+            width: 95%;
             padding: 12px;
             font-size: 1.1em;
             background: var(--input-bg);


### PR DESCRIPTION
implementation can be seen on my fork's index

Before:
<img width="1010" height="785" alt="image" src="https://github.com/user-attachments/assets/92f82883-2756-4342-b0ed-ee95e4b28151" />


After:
<img width="1010" height="785" alt="image" src="https://github.com/user-attachments/assets/2ea73bd2-7b83-405e-ac54-fa651a9367d9" />

https://github.com/NanashiTheNameless/Orca-Slicer-Assistant
https://orcahelp.namelessnanashi.dev/