### PR TITLE
Match OrcaSlicer visual style & add active card outline

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,16 +6,18 @@
     <title>Orca Slicer AIO Configuration Assistant</title>
     <style>
         :root {
-            --main-color: #ff0000;
-            --main-gradient: linear-gradient(90deg, #ff2a2a 0%, #ff0000 100%);
+            --main-color: #009789;
+            --secondary-color: #01675c;
+            --main-gradient: linear-gradient(90deg, var(--secondary-color) 0%, var(--main-color) 100%);
             --background-color: #18191c;
             --card-bg: #232326;
             --text-color: #fff;
+            --card-text-color: #fff;
             --input-bg: #2c2c2e;
             --input-text: #fff;
-            --button-bg: var(--main-color);
+            --button-bg: var(--secondary-color);
             --button-text: #fff;
-            --button-active: #b30000;
+            --button-active: var(--main-color);
             --shadow: 0px 4px 16px rgba(0,0,0,0.25);
             --border-radius: 16px;
             --section-title-size: 1.15em;
@@ -23,21 +25,14 @@
             --link-color: #fff;
         }
         html[data-theme="light"] {
-            --main-color: #ff0000;
-            --main-gradient: linear-gradient(90deg, #ff2a2a 0%, #ff0000 100%);
             --background-color: #f5f5f7;
             --card-bg: #fff;
             --text-color: #222;
+            --card-text-color: #515151;
             --input-bg: #f0f0f0;
             --input-text: #222;
-            --button-bg: #ff0000;
-            --button-text: #fff;
-            --button-active: #b30000;
             --shadow: 0px 4px 16px rgba(0,0,0,0.08);
-            --border-radius: 16px;
-            --section-title-size: 1.15em;
-            --section-title-weight: 700;
-            --link-color: #ff0000;
+            --link-color: var(--main-color);
         }
         body {
             background: var(--background-color);
@@ -54,6 +49,7 @@
             border-top-left-radius: var(--border-radius);
             border-top-right-radius: var(--border-radius);
             position: relative;
+            height: 62px;
         }
         .header-title {
             font-size: 2em;
@@ -74,8 +70,8 @@
         }
         .theme-toggle {
             position: absolute;
-            top: 14px;
-            right: 24px;
+            top: 26px;
+            right: 26px;
             background: rgba(255,255,255,0.12);
             border: none;
             width: 40px;
@@ -87,9 +83,11 @@
             cursor: pointer;
             z-index: 10;
             transition: background 0.2s;
+            box-shadow: rgba(0, 0, 0, 0.1) 0px 20px 25px -5px, rgba(0, 0, 0, 0.04) 0px 10px 10px -5px;
         }
         .theme-toggle:hover {
             background: rgba(255,255,255,0.22);
+            box-shadow: rgba(0, 0, 0, 0.06) 0px 2px 4px 0px inset;
         }
         .theme-toggle::before {
             content: '🌙';
@@ -99,28 +97,24 @@
             content: '☀️';
         }
         .assistant-container {
-            max-width: 1000px;
-            margin: -24px auto 0 auto;
-            padding: 0 16px 32px 16px;
-        }
-        .grid-padding {
-            height: 64px;
+            margin: 40px auto 40px auto;
+            padding: 0 40px 0 40px;
         }
         .grid {
             display: flex;
             flex-wrap: wrap;
-            gap: 24px;
+            gap: 40px;
             align-items: flex-start;
+            justify-content: space-evenly;
         }
         .card-section {
-            width: 48%;
+            width: 30%;
             min-width: 320px;
             max-width: 100%;
             box-sizing: border-box;
             background: var(--card-bg);
             border-radius: var(--border-radius);
             box-shadow: var(--shadow);
-            margin-bottom: 24px;
             display: block;
         }
         .card-header {
@@ -155,6 +149,10 @@
             opacity: 1;
             transition: max-height 0.3s cubic-bezier(.4,0,.2,1), opacity 0.2s;
             overflow: hidden;
+            padding-bottom: 12px;
+        }
+        .card-section.open {
+            height: 28rem;
         }
         .card-section.closed .card-content {
             max-height: 0;
@@ -162,14 +160,16 @@
             padding-top: 0;
             padding-bottom: 0;
         }
-        @media (max-width: 900px) {
+        .card-active {
+            border: 2px var(--secondary-color) solid;
+        }
+        @media (width < 760px) {
             .grid {
                 flex-direction: column;
             }
             .card-section {
                 width: 100%;
                 min-width: 0;
-                margin-bottom: 24px;
             }
         }
         label {
@@ -179,7 +179,6 @@
             font-weight: 500;
         }
         input, select {
-            width: 100%;
             padding: 12px;
             font-size: 1.1em;
             background: var(--input-bg);
@@ -189,25 +188,31 @@
             margin-bottom: 14px;
             font-weight: 500;
         }
+        input {
+            width: 95%;
+        }
+        select {
+            width: 100%;
+        }
         input:focus, select:focus {
-            outline: 2px solid var(--main-color);
+            outline: 4px solid var(--main-color);
         }
         .result {
             margin-top: 10px;
             font-size: 1.15em;
-            color: var(--main-color);
+            color: #00b9a8;
             font-weight: 700;
-            background: rgba(255,0,0,0.08);
+            background: rgba(0,151,137,0.12);
             border-radius: 8px;
             padding: 10px 0 10px 12px;
         }
         .history-item {
-            color: #fff;
-            background: rgba(255,0,0,0.12);
+            color: var(--card-text-color);
+            background: rgba(0,151,137,0.12);
             border-radius: 8px;
             font-size: 0.98em;
             margin-top: 8px;
-            padding: 6px 0 6px 12px;
+            padding: 8px 0 8px 12px;
         }
         .badge-new {
             background: var(--main-color);
@@ -222,16 +227,16 @@
             margin-right: 8px;
         }
         .footer {
-            margin-top: 32px;
+            margin-top: 60px;
             text-align: center;
             font-size: 0.98em;
-            color: #fff;
+            color: var(--text-color);
             opacity: 0.7;
         }
         .footer a {
             color: var(--link-color);
             text-decoration: underline;
-            margin: 0 8px;
+            margin: 0 4px;
         }
         .footer a:hover {
             text-decoration: underline;
@@ -245,7 +250,6 @@
         <button class="theme-toggle" onclick="toggleTheme()"></button>
     </div>
     <div class="assistant-container">
-        <div class="grid-padding"></div>
         <div class="grid">
             <div class="card-section open" id="card-pa">
                 <div class="card-header" onclick="toggleCard('pa')"><span class="chevron">▶</span><span class="emoji">⚡</span>Pressure Advance</div>
@@ -345,7 +349,12 @@
             const historyItem = document.getElementById(id);
             if (historyItem) historyItem.textContent = "Last Result: " + value;
         }
+        function setActiveCard(cardId) {
+            document.querySelectorAll('.card-active').forEach(el => el.classList.remove('card-active'));
+            document.getElementById(cardId)?.classList.add('card-active');
+        }
         function calculatePA() {
+            setActiveCard('card-pa')
             var circle = document.getElementById("circle").value;
             var entry1 = parseFloat(document.getElementById("entry1").value);
             var entry2 = parseFloat(document.getElementById("entry2").value);
@@ -361,6 +370,7 @@
             }
         }
         function calculateFlowRate() {
+            setActiveCard('card-flow')
             var flowRate = parseFloat(document.getElementById("flowRate").value);
             var modifier = parseFloat(document.getElementById("flowModifier").value);
             var result = flowRate * (100 + modifier) / 100;
@@ -368,6 +378,7 @@
             updateHistory("flow-history", result.toFixed(5));
         }
         function calculateRetraction() {
+            setActiveCard('card-retraction')
             var start = parseFloat(document.getElementById("start").value);
             var measuredHeight = parseFloat(document.getElementById("measuredHeight").value);
             var factor = parseFloat(document.getElementById("factor").value);
@@ -376,6 +387,7 @@
             updateHistory("retraction-history", result.toFixed(5));
         }
         function calculateMaxSpeed() {
+            setActiveCard('card-maxspeed')
             var maxSpeedStart = parseFloat(document.getElementById("maxSpeedStart").value);
             var maxSpeedHeight = parseFloat(document.getElementById("maxSpeedHeight").value);
             var maxSpeedStep = parseFloat(document.getElementById("maxSpeedStep").value);
@@ -384,6 +396,7 @@
             updateHistory("max-speed-history", result.toFixed(2));
         }
         function calculateYOLO() {
+            setActiveCard('card-yolo')
             const flowRatioOld = parseFloat(document.getElementById('flowRatioOld').value) || 0;
             const modifier = parseFloat(document.getElementById('yoloModifier').value) || 0;
             const flowRatioNew = flowRatioOld + modifier;
@@ -414,6 +427,10 @@
             calculateRetraction();
             calculateMaxSpeed();
             calculateYOLO();
+
+            // Get active card id from url params
+            setActiveCard(new URL(location.href).searchParams.get('active-card'));
+
             // Ensure all cards are open on load
             ['pa','flow','retraction','maxspeed','yolo'].forEach(function(card) {
                 var cardDiv = document.getElementById('card-' + card);


### PR DESCRIPTION
- Changed theme colours to match OrcaSlicer branding
- Adjusted certain colours to improve legibility
- Adaptive column count in relation to the size of the viewport
- Fix padding & responsive design bugs
- Expands on #7 to fix width of select fields as well

I also added an outline for the most recently modified card, to easily keep track when having to tab between Orca and this site.

You can also pass in a card id as a url parameter (ex. `?active-card=card-pa`) which allows you intuitively guide users towards the right card, when being linked from orca. [Here's an example for the pressure advance card.](https://orcalibrate.socuul.dev/?active-card=card-pa)
